### PR TITLE
Corrected Version field on Download List and History contracts.

### DIFF
--- a/SharpLEX/Contracts/DownloadHistory.cs
+++ b/SharpLEX/Contracts/DownloadHistory.cs
@@ -21,7 +21,7 @@ namespace SharpLEX.Contracts.History
     {
         public int Id { get; private set; }
         public string Name { get; private set; }
-        public string Verion { get; private set; }
+        public string Version { get; private set; }
         public string Author { get; private set; }
 
         [DeserializeAs(Name = "update_date")]

--- a/SharpLEX/Contracts/DownloadList.cs
+++ b/SharpLEX/Contracts/DownloadList.cs
@@ -18,7 +18,7 @@ namespace SharpLEX.Contracts.Future
     {
         public int Id { get; private set; }
         public string Name { get; private set; }
-        public string Verion { get; private set; }
+        public string Version { get; private set; }
         public string Author { get; private set; }
         [DeserializeAs(Name = "update_date")]
         public DateTime? LastUpdated { get; private set; }


### PR DESCRIPTION
Here's the pull request with the fix from the Version field on those contract classes.